### PR TITLE
Normalize the version at setuptools' urging

### DIFF
--- a/bfg9000/version.py
+++ b/bfg9000/version.py
@@ -1,1 +1,1 @@
-version = '0.1.0-dev'
+version = '0.1.0.dev0'


### PR DESCRIPTION
Without this we get an annoying warning whenever we ask setuptools to do anything:

```
/home/travis/virtualenv/python3.5.0/lib/python3.5/site-packages/setuptools/dist.py:283: UserWarning: The version specified requires normalization, consider using '0.1.0.dev0' instead of '0.1.0-dev'.
  self.metadata.version,
```