### PR TITLE
Experiment in making keywords importable.

### DIFF
--- a/bfg9000/build.py
+++ b/bfg9000/build.py
@@ -7,6 +7,7 @@ from .build_inputs import BuildInputs
 from .path import exists, Path, pushd, Root
 from .iterutils import listify
 from .tools import init as tools_init
+from . import keywords
 
 bfgfile = 'build.bfg'
 optsfile = 'options.bfg'
@@ -36,6 +37,9 @@ def _execute_script(f, context, path, run_post=False):
          context.push_path(path) as p:  # noqa
         code = compile(f.read(), filename, 'exec')
         try:
+            for keyword, value in context.builtins.items():
+                if hasattr(keywords, keyword):
+                    setattr(keywords, keyword, value)
             exec(code, context.builtins)
         except SystemExit as e:
             if e.code:

--- a/bfg9000/keywords.py
+++ b/bfg9000/keywords.py
@@ -1,0 +1,76 @@
+"""Keywords available in build.cfg files.
+
+Note that the values in this module are actually replaced by bfg9000 when a build.cfg is run, so don't rely on these to
+act like normal Python attributes.
+"""
+
+# It would be better if each of these referred to some object with the correct signature and docstring so that things
+# like autocomplete would work naturally in any IDE. I'm not sure if there's a simple way for us to automate that.
+
+# Note that this list of attributes was created by looking at the names that are actually injected into the build.cfg
+# namespace. If some of these should not be in here, they can safely be removed. The code that populates this module
+# won't add names that aren't already here.
+
+CalledProcessError = None
+FindResult = None
+InstallRoot = None
+PackageResolutionError = None
+PackageVersionError = None
+Path = None
+Root = None
+ToolNotFoundError = None
+VersionError = None
+__bfg9000__ = None
+alias = None
+argv = None
+auto_file = None
+bfg9000_required_version = None
+bfg9000_version = None
+boost_package = None
+build_step = None
+command = None
+copy_file = None
+copy_files = None
+debug = None
+default = None
+directory = None
+env = None
+executable = None
+export = None
+extra_dist = None
+filter_by_platform = None
+find_files = None
+find_paths = None
+framework = None
+generated_source = None
+generated_sources = None
+generic_file = None
+global_link_options = None
+global_options = None
+header_directory = None
+header_file = None
+info = None
+install = None
+library = None
+module_def_file = None
+object_file = None
+object_files = None
+opts = None
+package = None
+pkg_config = None
+precompiled_header = None
+project = None
+relpath = None
+resource_file = None
+safe_format = None
+safe_str = None
+shared_library = None
+source_file = None
+static_library = None
+submodule = None
+system_executable = None
+test = None
+test_deps = None
+test_driver = None
+warning = None
+whole_archive = None


### PR DESCRIPTION
This provides a way for `build.cfg` files to import the various bfg keywords. The primary reason for this is so that IDEs will know about these symbols and not treat them as errors. This addresses #135.

The technique I'm using introduces a new module `bfg9000.keywords`. This has a module-level attribute for each of the bfg9000 keywords; they all currently point to `None`, but they could point to something more useful (see notes in the file).

When the `build.cfg` is executed, `bfg9000.build._execute_script` replaces the values in `keywords` with the actual objects. 

The result is that you can have a `build.cfg` like this:
```
from bfg9000.keywords import alias, default, build_step

# rest of build definition, just like any other.
```
and any Python-aware IDE will at least recognize that `alias`, `default`, and `build_step` are legitimate identifiers.

This PR is more about getting feedback on the approach and details (e.g. naming). It's certainly missing some details like handling `options.cfg`.